### PR TITLE
Added logic to support host mode

### DIFF
--- a/src/livestreamer/plugins/twitch.py
+++ b/src/livestreamer/plugins/twitch.py
@@ -167,8 +167,11 @@ class TwitchAPI(object):
 
         if self.oauth_token:
             params["oauth_token"] = self.oauth_token
-
-        url = "https://{0}.twitch.tv{1}.{2}".format(self.subdomain, path, format)
+        
+        if len(format) > 0:
+            url = "https://{0}.twitch.tv{1}.{2}".format(self.subdomain, path, format)
+        else:
+            url = "https://{0}.twitch.tv{1}".format(self.subdomain, path)
 
         # The certificate used by Twitch cannot be verified on some OpenSSL versions.
         res = http.get(url, params=params, verify=False)
@@ -177,6 +180,13 @@ class TwitchAPI(object):
             return http.json(res, schema=schema)
         else:
             return res
+    
+    def call_subdomain(self, subdomain, path, format="json", schema=None, **extra_params):
+        subdomain_buffer = self.subdomain
+        self.subdomain = subdomain
+        response = self.call(path, format=format, schema=schema, **extra_params)
+        self.subdomain = subdomain_buffer
+        return response
 
     def access_token(self, endpoint, asset, **params):
         return self.call("/api/{0}/{1}/access_token".format(endpoint, asset), **params)
@@ -201,12 +211,16 @@ class TwitchAPI(object):
 
     def viewer_info(self, **params):
         return self.call("/api/viewer/info", **params)
+    
+    def  hosted_channel(self, **params):
+        return self.call_subdomain("tmi", "/hosts", format="", **params)
 
 
 class Twitch(Plugin):
     options = PluginOptions({
         "cookie": None,
         "oauth_token": None,
+        "allow_host": None,
     })
 
     @classmethod
@@ -223,7 +237,6 @@ class Twitch(Plugin):
 
     def __init__(self, url):
         Plugin.__init__(self, url)
-
         match = _url_re.match(url).groupdict()
         self.channel = match.get("channel").lower()
         self.subdomain = match.get("subdomain")
@@ -414,9 +427,17 @@ class Twitch(Plugin):
                 raise
 
         return sig, token
+    
+    def _check_for_host(self):
+        channel_id = self.api.channel_info(self.channel)["_id"]
+        host_info = self.api.hosted_channel(include_logins=1, host=channel_id).json()["hosts"][0]
+        if "target_login" in host_info:
+            self.logger.info("{0} is in host mode, switching to {1}".format(self.channel, host_info["target_login"]))
+            self.channel = host_info["target_login"]
 
     def _get_hls_streams(self, type="live"):
         self._authenticate()
+        self._check_for_host()
         sig, token = self._access_token(type)
         if type == "live":
             url = self.usher.channel(self.channel, sig=sig, token=token)


### PR DESCRIPTION
- TwitchAPI required support for varying subdomains, so I added call_subdomain to solve this. It just temporarily changes the subdomain to the requested one.
- TwitchAPI did not have a function for calling the hosts api, so I added hosted_channel to get the necessary information.
- Added option "allow_host" to the PluginOptions, not fully integrated yet.
- Added _check_for_host that determines if the requested channel is in host mode, then switches to the appropriate channel.
- Added a call to _check_for_host in _get_hls_streams before requesting _access_token to make sure the hosted channel's access token is requested
